### PR TITLE
feat: add custom AdEventListener to Manilo

### DIFF
--- a/kohii-ads/api/kohii-ads.api
+++ b/kohii-ads/api/kohii-ads.api
@@ -49,7 +49,10 @@ public final class kohii/v1/ads/Manilo : kohii/v1/exoplayer/Kohii, com/google/ad
 	public synthetic fun <init> (Landroid/content/Context;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkohii/v1/core/Master;Lkohii/v1/core/PlayableCreator;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Lkohii/v1/core/Master;Lkohii/v1/core/PlayableCreator;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun addAdEventListener (Lcom/google/ads/interactivemedia/v3/api/AdEvent$AdEventListener;)V
 	public fun onAdEvent (Lcom/google/ads/interactivemedia/v3/api/AdEvent;)V
+	public final fun removeAdEventListener (Lcom/google/ads/interactivemedia/v3/api/AdEvent$AdEventListener;)V
+	public final fun removeAllAdEventListener ()V
 }
 
 public final class kohii/v1/ads/Manilo$Companion {

--- a/kohii-ads/src/main/java/kohii/v1/ads/Manilo.kt
+++ b/kohii-ads/src/main/java/kohii/v1/ads/Manilo.kt
@@ -63,6 +63,8 @@ class Manilo(
   rendererProviderFactory: RendererProviderFactory = { PlayerViewProvider() }
 ) : Kohii(master, playableCreator, rendererProviderFactory), AdEventListener {
 
+  private val adEventListeners = mutableSetOf<AdEventListener>()
+
   private constructor(context: Context) : this(Master[context])
 
   /**
@@ -198,9 +200,21 @@ class Manilo(
   }
 
   // AdEventListener
+  fun addAdEventListener(listener: AdEventListener) {
+    adEventListeners.add(listener)
+  }
+
+  fun removeAdEventListener(listener: AdEventListener) {
+    adEventListeners.remove(listener)
+  }
+
+  fun removeAllAdEventListener() {
+    adEventListeners.clear()
+  }
 
   // This callback only works when [Manilo] uses a default [ImaAdsLoader.Builder].
   override fun onAdEvent(adEvent: AdEvent) {
     "AdEvent: $adEvent".logInfo()
+    adEventListeners.forEach { it.onAdEvent(adEvent) }
   }
 }

--- a/kohii-sample/src/main/java/kohii/v1/sample/ui/ads/AdsContainerFragment.kt
+++ b/kohii-sample/src/main/java/kohii/v1/sample/ui/ads/AdsContainerFragment.kt
@@ -35,6 +35,7 @@ import kohii.v1.sample.common.ViewBindingFragment
 import kohii.v1.sample.databinding.FragmentAdsListBinding
 import okio.buffer
 import okio.source
+import timber.log.Timber
 
 class AdsContainerFragment :
     ViewBindingFragment<FragmentAdsListBinding>(FragmentAdsListBinding::inflate) {
@@ -92,6 +93,10 @@ class AdsContainerFragment :
     super.onViewCreated(view, savedInstanceState)
 
     manilo.register(this).addBucket(requireBinding().playerContainer)
+
+    manilo.addAdEventListener {
+      Timber.d("AdEventListener received : $it")
+    }
 
     val layoutManager = LinearLayoutManager(view.context)
     requireBinding().adsContainer.layoutManager = layoutManager


### PR DESCRIPTION
This PR will allow user to register/unregister AdEventListener on a Manilo instance.
