### PR TITLE
Release changelog for version 1.1.1.2011003 is incorrect - it states usage of ExoPlayer 2.11.3 whereas in fact 2.11.7 is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- ExoPlayer: 2.11.7
 - Fix an issue that cause cache doesn't write to file (https://github.com/eneim/kohii/pull/91);
 
 ## 1.1.0.2011003


### PR DESCRIPTION
In fact the underlying version of ExoPlayer in use is 2.11.7., 2011007. Maybe this should be noted in the changelog as a mistake and a new version of Kohii (for example 1.1.2.2011007) should be released instead?

Cheers,