### PR TITLE
feat: Update ExoPlayer to 2.15.1

### DIFF
--- a/buildSrc/src/main/java/kohii/Dependencies.kt
+++ b/buildSrc/src/main/java/kohii/Dependencies.kt
@@ -18,9 +18,9 @@ package kohii
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 object Versions {
-  const val exoPlayer = "2.14.2"
+  const val exoPlayer = "2.15.1"
   const val exoPlayerSnapShot = "dev-v2-r${exoPlayer}-SNAPSHOT"
-  const val exoPlayerCode = 2014002
+  const val exoPlayerCode = 2015001
 }
 
 object ReleaseInfo {

--- a/kohii-core/src/main/java/kohii/v1/core/Interfaces.kt
+++ b/kohii-core/src/main/java/kohii/v1/core/Interfaces.kt
@@ -17,6 +17,7 @@
 package kohii.v1.core
 
 import com.google.android.exoplayer2.ExoPlaybackException
+import com.google.android.exoplayer2.PlaybackException
 import com.google.android.exoplayer2.PlaybackParameters
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.Player.PositionInfo
@@ -62,7 +63,7 @@ class PlayerEventListeners : CopyOnWriteArraySet<Player.Listener>(), Player.List
     trackSelections: TrackSelectionArray
   ): Unit = forEach { it.onTracksChanged(trackGroups, trackSelections) }
 
-  override fun onPlayerError(error: ExoPlaybackException): Unit =
+  override fun onPlayerError(error: PlaybackException) =
     forEach { it.onPlayerError(error) }
 
   override fun onIsLoadingChanged(isLoading: Boolean): Unit =


### PR DESCRIPTION
## Overview
Update Exo Player to 2.15.1 and change exception type from `ExoPlaybackException` to `PlaybackException` in `onPlayerError(error: _)` call.

## About PlaybackException
That's new error instance implemented in ExoPlayer 2.15.0.

> Player implementations like ExoPlayer may use PlaybackException subclasses (like ExoPlaybackException), so users can downcast the PlaybackException instance to obtain implementation-specific fields (like ExoPlaybackException.rendererIndex).

FROM: [ExoPlayer 2.15.0 release notes](https://github.com/google/ExoPlayer/releases/tag/r2.15.0#:~:text=Player%20implementations%20like%20ExoPlayer%20may%20use%20PlaybackException%20subclasses%20(like%20ExoPlaybackException)%2C%20so%20users%20can%20downcast%20the%20PlaybackException%20instance%20to%20obtain%20implementation-specific%20fields%20(like%20ExoPlaybackException.rendererIndex).)

## Note
This PR has no effect on the behavior.
To check this issue, I have taken the following steps.

1. Open **kohii-sample-tiktok** exapmle project and edit video file path in caminandes.json before launching task.
2. While the task is running, an exception `ExoPlaybackExeception` should be shown in console that is caused by file missing.
3. It can be seen in both branch dev-v1 and this PR branch, so no change in behavior it means.

 | branch dev-v1 | branch dev-platong/v1/exoplayer-2-15-1 |
 | -- | -- |
 | ![スクリーンショット 2021-10-25 17 49 47](https://user-images.githubusercontent.com/33997070/138669667-5ad82c2e-d97e-43fb-ae66-84c0316b8845.png) |![スクリーンショット 2021-10-25 17 58 33](https://user-images.githubusercontent.com/33997070/138669701-9b67b74e-cd55-415a-953b-ec0c06611539.png)| 